### PR TITLE
P2P Implementation

### DIFF
--- a/docs/code_style.md
+++ b/docs/code_style.md
@@ -11,6 +11,13 @@ network.c:
 void network_connect(...);
 ```
 
+Private functions are prepended with two underscores.
+
+Example:
+```c
+void __network_private_function();
+```
+
 ---
 
 ## TODO

--- a/privanet/main.c
+++ b/privanet/main.c
@@ -5,26 +5,14 @@
 #include <unistd.h>
 
 #include "data/linkedlist.h"
+#include "net/network.h"
+#include "net/p2p.h"
 #include "privanet.h"
-#include "network.h"
 
 int main()
 {
-	struct linked_list known_hosts = linked_list_create();
-	linked_list_insert(&known_hosts, 0, "127.0.0.1", 10);
-
-	pthread_t thread_server;
-
-	// create server/client threads	
-	pthread_create(&thread_server, NULL, network_server, &known_hosts);
-	
-	while(1) {
-		char request[REQUEST_BUFFER_SIZE];
-		memset(request, 0, REQUEST_BUFFER_SIZE);
-		printf("REQUEST: ");
-		fgets(request, REQUEST_BUFFER_SIZE, stdin);
-		network_client(request, &known_hosts);
-	}
+	struct p2p p2p = p2p_create(AF_INET, SOCK_STREAM, 0, PRIVANET_PORT, INADDR_ANY);
+	p2p_user_portal(&p2p);
 
 	return 0;
 }

--- a/privanet/main.c
+++ b/privanet/main.c
@@ -5,6 +5,7 @@
 #include <unistd.h>
 
 #include "data/linkedlist.h"
+#include "privanet.h"
 #include "network.h"
 
 int main()
@@ -18,10 +19,10 @@ int main()
 	pthread_create(&thread_server, NULL, network_server, &known_hosts);
 	
 	while(1) {
-		char request[256];
-		memset(request, 0, 256);
+		char request[REQUEST_BUFFER_SIZE];
+		memset(request, 0, REQUEST_BUFFER_SIZE);
 		printf("REQUEST: ");
-		fgets(request, 256, stdin);
+		fgets(request, REQUEST_BUFFER_SIZE, stdin);
 		network_client(request, &known_hosts);
 	}
 

--- a/privanet/net/network.h
+++ b/privanet/net/network.h
@@ -4,7 +4,7 @@
 #include <netinet/in.h>
 #include <sys/socket.h>
 
-#include "data/linkedlist.h"
+#include "../data/linkedlist.h"
 
 struct server {
 	int domain;
@@ -32,8 +32,9 @@ struct client {
 struct server network_create_server(int domain, int service, int protocol, u_long interface, int port, int backlog);
 struct client network_create_client(int domain, int service, int protocol, int port, u_long interface);
 
-void *network_server(void *known_hosts);
-void network_client(char *request, struct linked_list *known_hosts);
+void *network_server(void *arg);
+void *network_server_no_multithreading(void *arg);
+void *network_client(void *arg);
 
 /****
  * PRIVATE FUNCTIONS

--- a/privanet/net/p2p.c
+++ b/privanet/net/p2p.c
@@ -1,0 +1,40 @@
+#include <stdlib.h>
+#include <string.h>
+#include <stdio.h>
+#include <pthread.h>
+
+#include "../privanet.h"
+
+#include "../data/linkedlist.h"
+
+#include "network.h"
+#include "p2p.h"
+
+struct p2p p2p_create(int domain, int service, int protocol, int port, u_long interface)
+{
+	struct p2p new_p2p;
+	new_p2p.domain = domain;
+	new_p2p.service = service;
+	new_p2p.protocol = protocol;
+	new_p2p.port = port;
+	new_p2p.interface = interface;
+
+	new_p2p.known_hosts = linked_list_create();
+	
+	// TODO: this is temporary so we don't have to run multiple instances
+	// of this program to test it
+	linked_list_insert(&new_p2p.known_hosts, 0, "127.0.0.1", 10);
+
+	new_p2p.server_func = network_server_no_multithreading;
+	new_p2p.client_func = network_client;
+
+	return new_p2p;
+}
+
+void p2p_user_portal(struct p2p *p2p)
+{
+	pthread_t server_thread;
+	pthread_create(&server_thread, NULL, p2p->server_func, p2p);
+
+	p2p->client_func(p2p);
+}

--- a/privanet/net/p2p.h
+++ b/privanet/net/p2p.h
@@ -1,0 +1,27 @@
+#ifndef __P2P_H_
+#define __P2P_H_
+
+#include <unistd.h>
+
+#include "../data/linkedlist.h"
+#include "network.h"
+
+struct p2p {
+	struct server server;
+	struct linked_list known_hosts;
+
+	int domain;
+	int service;
+	int protocol;
+	int port;
+	u_long interface;
+
+	void *(*server_func)(void *arg);
+	void *(*client_func)(void *arg);
+};
+
+struct p2p p2p_create(int domain, int service, int protocol, int port, u_long interface);
+
+void p2p_user_portal(struct p2p *p2p);
+
+#endif /* __P2P_H_ */

--- a/privanet/network.c
+++ b/privanet/network.c
@@ -6,6 +6,7 @@
 #include <sys/types.h>
 #include <unistd.h>
 
+#include "privanet.h"
 #include "network.h"
 
 #include "data/linkedlist.h"
@@ -118,9 +119,9 @@ void *__network_server_loop(void *arg)
 {
 	struct server_arg *server_arg = arg;
 
-	char request[256];
-	memset(request, 0, 256);
-	read(server_arg->client, request, 256);
+	char request[REQUEST_BUFFER_SIZE];
+	memset(request, 0, REQUEST_BUFFER_SIZE);
+	read(server_arg->client, request, REQUEST_BUFFER_SIZE);
 	
 	char *client_addr = inet_ntoa(server_arg->server->address.sin_addr);
 

--- a/privanet/privanet.h
+++ b/privanet/privanet.h
@@ -1,6 +1,7 @@
 #ifndef __PRIVANET_H_
 #define __PRIVANET_H_
 
+#define PRIVANET_PORT 9999
 #define REQUEST_BUFFER_SIZE 256
 
 #endif /* __PRIVANET_H_ */

--- a/privanet/privanet.h
+++ b/privanet/privanet.h
@@ -1,0 +1,6 @@
+#ifndef __PRIVANET_H_
+#define __PRIVANET_H_
+
+#define REQUEST_BUFFER_SIZE 256
+
+#endif /* __PRIVANET_H_ */


### PR DESCRIPTION
This PR is a continuation of #1, finishing Peer-to-Peer connection.
Everything added in this PR and #1 will be documented here.

# Added
##### Networking
- P2P Multithreaded Server/Client
- P2P Server with multithreading disabled
- Node discovery
- Sending requests to all nodes

##### Data Structures
- Linked Lists
- Nodes
- Queues (fancy linked lists)

##### Threading
- Thread pools (pre-allocated threads)

# Current limitations
- Maximum number of connections is set to 50 (see below)
- Requests are made by user (user types a request and then it is sent)
- Maximum length of a request is 255 characters

##### Maximum number of connections
Thread pool is allocated to 50 threads by default. If the number of connections exceed this limit, it is UB.

# How to use this program at the current state
After running, the program shall inform you that it has started a server on port 9999 (default). Write anything and press enter, the program shall repeat it back to you.

# Notes
- The program will repeat your own messages by default. If you wish to stop this behavior, remove the relevant line in `net/p2p.c` that inserts `127.0.0.1` into known hosts.
- Node discovery has not been tested.
- The program starts with a non-multithreaded server by default. To change this, change `new_p2p.server_func` to `network_server` in the function `p2p_create()`.